### PR TITLE
Fixed setup script printing help message in non-interactive mode

### DIFF
--- a/lib/setup
+++ b/lib/setup
@@ -60,7 +60,7 @@ for i in "$@"
         esac
     done
 
-if [[ -z "$@" ]] || [[ "$HELP" == "1" ]]; then
+if [[ ! -z "$@" ]] || [[ "$HELP" == "1" ]]; then
 
     print_header \
         'Mage2click' \

--- a/lib/setup
+++ b/lib/setup
@@ -35,6 +35,9 @@ function in_array()
     return ${in}
 }
 
+# Implicit --help if no arguments are passed
+[[ -z "$@" ]] && HELP=1
+
 for i in "$@"
     do
         case ${i} in

--- a/lib/setup
+++ b/lib/setup
@@ -56,7 +56,9 @@ for i in "$@"
             --cron) CRON=1; shift;;
             --composer) COMPOSER=1; shift;;
 
-            *) ;;
+            *)
+                >&2 printf "\e[01;31mError: Unrecognized argument: %s\n" "${i}"
+                ;;
         esac
     done
 

--- a/lib/setup
+++ b/lib/setup
@@ -42,7 +42,7 @@ for i in "$@"
     do
         case ${i} in
             -h|--help) HELP=1; break;;
-            -i|--interactive) INTERACTIVE=1; break;;
+            -i|--interactive) INTERACTIVE=1; shift; break;;
 
             --domain=*) DOMAIN="${i#*=}"; shift;;
             --magento-archive=*) ARCHIVE="${i#*=}"; shift;;


### PR DESCRIPTION
Running the following (for example) would fail prior to this change:
```
setup.sh --domain=mysite.test --magento-db=/tmp/mysite.sql --magento-project=/sites/vaporbeast.vbst --php-version=7.1 --mailhog --rabbitmq --elasticsearch --elasticsearch-version=5.6
```

Adding any invalid argument would allow the command to run. The change in logic here corrects the conditional to print the help message when there are leftover arguments (i.e. arguments unparsed by the loop above this) resolving the issue and allowing non-interactive setup to work as expected.

This also adds error handling on the argument parsing to print a message informing the user which argument the loop failed to parse:
```
$ ./setup.sh --foo=bar --foobar
Error: Unrecognized argument: --foo=bar
Error: Unrecognized argument: --foobar
+------------------------------------------------------+
|                                                      |
| Mage2click                                           |
|                                                      |
| #Docker #Magento #Mutagen development environment    |
|                                                      |
| https://mage2.click                                  |
| https://github.com/mage2click/docker-magento-mutagen |
|                                                      |
+------------------------------------------------------+
```
