### PR TITLE
Fixed bin/setup/start to properly strip definers on db import

### DIFF
--- a/compose/magento-2/bin/setup/start
+++ b/compose/magento-2/bin/setup/start
@@ -125,7 +125,8 @@ if [[ -z "$DB" ]]; then
                     --use-rewrites=1
 else
     echo "Importing database..."
-    bin/clinotty mysql -hdb -umagento -pmagento magento < "$DB"
+    bin/clinotty bash -c 'LC_ALL=C sed -e '\''s/DEFINER[ ]*=[ ]*[^*]*\*/\*/'\'' \
+        | mysql -hdb -umagento -pmagento magento' < "$DB"
 
     # Set base URLs to local environment URL:
     bin/clinotty bin/magento config:set web/secure/base_url "https://$DOMAIN/"


### PR DESCRIPTION
Magento 2 users TRIGGERs and when they are created on a foreign environment often have DEFINERs with invalid local users. The solution to this is piping the import through `sed` to strip DEFINERs from comments. This change supports that.