### PR TITLE
Fix for the installation log 

### DIFF
--- a/compose/magento-2/bin/setup/start
+++ b/compose/magento-2/bin/setup/start
@@ -30,6 +30,7 @@ if [[ ! -z "$COMPOSER" ]]; then
     fi
 
     rm -rf src/vendor #Clear for step below
+    mkdir src/vendor #Empty vendor directory for bin/fixperms script
 fi
 
 docker-compose up -d


### PR DESCRIPTION
Fix for "find: 'vendor': no such file or directory" in installation log with enabled composer install

![telegram-cloud-photo-size-2-5404368210985331432-y](https://user-images.githubusercontent.com/7448756/57972474-d57ed500-79a3-11e9-9413-d38a26770398.jpg)
