### PR TITLE
Setup Scripts Should Exit on Error or When User Aborts Them

### DIFF
--- a/compose/magento-2/bin/setup/download
+++ b/compose/magento-2/bin/setup/download
@@ -1,3 +1,5 @@
 #!/bin/bash
+set -e
+
 [[ -z "$1" ]] && echo "Please specify the version to download (ex. 2.3.1)" && exit
 mkdir -p src && curl -L http://pubfiles.nexcess.net/magento/ce-packages/magento2-$1.tar.gz | tar xzf - -o -C src

--- a/compose/magento-2/bin/setup/elasticsearch
+++ b/compose/magento-2/bin/setup/elasticsearch
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 if [[ "$1" == "2" ]]; then
     bin/clinotty bin/magento config:set --scope=default --scope-code=0 \
                 catalog/search/engine elasticsearch > /dev/null

--- a/compose/magento-2/bin/setup/import
+++ b/compose/magento-2/bin/setup/import
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 function spinner()
 {

--- a/compose/magento-2/bin/setup/redis
+++ b/compose/magento-2/bin/setup/redis
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 bin/clinotty bin/magento setup:config:set --no-interaction --cache-backend=redis \
                 --cache-backend-redis-server=redis --cache-backend-redis-db=0 > /dev/null
 

--- a/compose/magento-2/bin/setup/start
+++ b/compose/magento-2/bin/setup/start
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 for i in "$@"
     do
         case ${i} in

--- a/compose/magento-2/bin/setup/unzip
+++ b/compose/magento-2/bin/setup/unzip
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 function spinner()
 {

--- a/compose/magento-2/bin/setup/varnish
+++ b/compose/magento-2/bin/setup/varnish
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 for i in "$@"
     do
         case ${i} in

--- a/lib/setup
+++ b/lib/setup
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 function print_header()
 {


### PR DESCRIPTION
This PR simply adds `set -e` to the top of each of the setup scripts so that:

a) They will exit if/when any sub-command encounters an error

b) Setup will immediately stop when a user attempts to abort by typing Ctrl+C (this kills the active sub-command, and `set -e` allows the unclean exit to bubble up and terminate the parent setup script)
