### PR TITLE
Change Setup Behavior to Support Setup from Local Source Without Db

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ Parameters:
 - `--php-version=<version>` PHP version to use for the project, default is `7.2`. Currently supported PHP versions: `7.0`, `7.1` and `7.2`.
 - `--elasticsearch-version=<version>` Elasticsearch version to use for the project, default is `6.7.2`. Currently supported Elasticsearch versions: `2.4`, `5.6` and `6.7.2`.
 - `--magento-archive=<path>` Full path to downloaded Magento zip-archive to use in setup (optional).
-- `--magento-project=<path>` Full path to the existing Magento project to use in setup (optional). If specified, `--magento-db` parameter is required as well.
-- `--magento-db=<path>` Full path to sql-file with database dump to use in setup (optional). If specified, `--magento-project` parameter is required as well.
+- `--magento-project=<path>` Full path to the existing Magento project to use in setup (optional).
+- `--magento-db=<path>` Full path to sql-file with database dump to use in setup (optional).
 - `--magento-version=<version>` Magento version to download from the official repository, default is `2.3.1`. If `--magento-archive` parameter is specified, this will be skipped.
 
 Flags:

--- a/lib/setup
+++ b/lib/setup
@@ -495,7 +495,7 @@ echo
 
 if [[ ! -z "$ARCHIVE" ]]; then
     bin/setup/unzip ${ARCHIVE}
-elif [[ ! -z "$PROJECT" ]] && [[ ! -z "$DB" ]]; then
+elif [[ ! -z "$PROJECT" ]]; then
     bin/setup/import ${PROJECT}
 else
     bin/setup/download ${VERSION}


### PR DESCRIPTION
Currently the README stipulates that if `--magento-project` is specified, the `--magento-db` must be specified as well. Based on the setup scripts currently implemented however, this requirement does not appear to be there for a technical implementation reason, so I would like to propose lifting the restriction. This will support setting up a Mage2Click based environment using a local source directory without having a database artifact already present.

With this change, either parameter may be specified independently of the other allowing the setup process to either run `setup:install` or import the database from the provided dump file, even when a local project source directory is given, allowing for greater flexibility during the setup process.

Example use case would be setting up a Magento Commerce project from scratch using composer meta packages, where there is most likely no database artifact available for import during setup:

```
create-project -q --repository=https://repo.magento.com/ \
  magento/project-enterprise-edition /tmp/magento2-project 2.3.x

mkdir /sites/magento2-project && pushd /sites/magento2-project

cat /server/proj/docker-magento-mutagen/lib/setup | bash -s -- \
  --domain=magento2-project.test \
  --magento-project=/tmp/magento2-project \
  --varnish \
  && rm -rf /tmp/magento2-project
```
