### PR TITLE
Fix Erroneous Composer Prompts

### DIFF
--- a/compose/magento-2/bin/setup/start
+++ b/compose/magento-2/bin/setup/start
@@ -43,8 +43,8 @@ bin/copytocontainer --all
 bin/fixperms
 
 if hash composer 2>/dev/null; then
-    PUBLIC_KEY="$(composer config -ng http-basic.repo.magento.com.username 2>/dev/null)"
-    PRIVATE_KEY="$(composer config -ng http-basic.repo.magento.com.password 2>/dev/null)"
+    PUBLIC_KEY="$(composer config -ng http-basic.repo.magento.com.username 2>/dev/null || true)"
+    PRIVATE_KEY="$(composer config -ng http-basic.repo.magento.com.password 2>/dev/null || true)"
 fi
 
 echo

--- a/compose/magento-2/bin/setup/start
+++ b/compose/magento-2/bin/setup/start
@@ -43,8 +43,8 @@ bin/copytocontainer --all
 bin/fixperms
 
 if hash composer 2>/dev/null; then
-    PUBLIC_KEY="$(composer config -ngl | grep 'http-basic.repo.magento.com.username' | cut -f 2 -d ' ')"
-    PRIVATE_KEY="$(composer config -ngl | grep 'http-basic.repo.magento.com.password' | cut -f 2 -d ' ')"
+    PUBLIC_KEY="$(composer config -ng http-basic.repo.magento.com.username 2>/dev/null)"
+    PRIVATE_KEY="$(composer config -ng http-basic.repo.magento.com.password 2>/dev/null)"
 fi
 
 echo

--- a/compose/magento-2/bin/setup/start
+++ b/compose/magento-2/bin/setup/start
@@ -92,14 +92,14 @@ if [[ -z "$RES" ]] || [[ -z "$PUBLIC_KEY" ]] && [[ -z "$PRIVATE_KEY" ]]; then
         done </dev/tty
 
         if [[ "$RES" == "1" ]]; then
-            $(composer global config http-basic.repo.magento.com ${PUBLIC_KEY} ${PRIVATE_KEY}) > /dev/null
+            composer global config http-basic.repo.magento.com "${PUBLIC_KEY}" "${PRIVATE_KEY}" 2>/dev/null
         fi
     fi
     echo
 fi
 
 if [[ -n "$PUBLIC_KEY" ]] && [[ -n "$PRIVATE_KEY" ]]; then
-    bin/clinotty composer config http-basic.repo.magento.com ${PUBLIC_KEY} ${PRIVATE_KEY}
+    bin/clinotty composer config http-basic.repo.magento.com "${PUBLIC_KEY}" "${PRIVATE_KEY}"
 fi
 
 if [[ ! -z "$COMPOSER" ]]; then

--- a/compose/magento-2/bin/setup/start
+++ b/compose/magento-2/bin/setup/start
@@ -43,8 +43,8 @@ bin/copytocontainer --all
 bin/fixperms
 
 if hash composer 2>/dev/null; then
-    PUBLIC_KEY="$(composer config -gl | grep 'http-basic.repo.magento.com.username' | cut -f 2 -d ' ')"
-    PRIVATE_KEY="$(composer config -gl | grep 'http-basic.repo.magento.com.password' | cut -f 2 -d ' ')"
+    PUBLIC_KEY="$(composer config -ngl | grep 'http-basic.repo.magento.com.username' | cut -f 2 -d ' ')"
+    PRIVATE_KEY="$(composer config -ngl | grep 'http-basic.repo.magento.com.password' | cut -f 2 -d ' ')"
 fi
 
 echo


### PR DESCRIPTION
When working in a sub-directory with no composer.json and where a parent directory has a composer.json file, composer will incorrectly present the following prompt when running `composer config -gl`:

```
No composer.json in current directory, do you want to use the one at /Volumes/Server? [Y,n]?
```

The addition of the `-n` flag silences this, making composer only look at the global composer auth.json file for the credentials as stipulated by the `-g` flag.

In addition to adding the `-n` (non-interactive) flag, I've also cleaned up the composer calls to lookup the creds without use of grep or cut. The `|| true` is there to silence any exit codes (and prevent them from bubbling up) similar to how they would have been silenced when running the output through a pipe. And I've cleaned up the odd wrapping of composer in `$()` on line 95 since this actually results in the output of composer being executed by `sh` as a command (resulting in an error).
