### PR TITLE
Fixed issue causing mutagen to infinitely retry scan on src/vendor

### DIFF
--- a/compose/magento-2/bin/mutagen
+++ b/compose/magento-2/bin/mutagen
@@ -42,6 +42,7 @@ elif [[ "$1" == "start" ]]; then
         --default-group-alpha=app \
         --sync-mode=two-way-resolved \
         --watch-mode-alpha=no-watch \
+        --symlink-mode=posix-raw \
         --ignore-vcs \
         docker://$(docker-compose ps -q phpfpm|awk '{print $1}')/var/www/html/vendor src/vendor
 elif [[ "$1" == "stop" ]]; then


### PR DESCRIPTION
Ran into this on both the Mediotype projects I attempted to setup with this docker environment. After setting them up, the mutagen process on the host machine was seeing 50-70% CPU usage every few seconds. The issue turned out to be one thing these projects both had in common: a local repository configured in the composer.json, something like this:

```
"external-modules": {
    "type": "path",
    "url": "modules/*/*",
    "options": {
        "symlink": true
    }
},
```

The issue here was caused by the `symlink: true` and resulted in a silent error that only revealed itself when inspecting the mutagen status via `mutagen list -l` in the output for the session for `src/vendor`:

```
Status: Waiting 5 seconds for rescan
Last error: beta scan error: invalid symbolic link (tpb/module-seo-snippets): target references location outside synchronization root
```

As can be seen from the above status message, every 5 seconds on these two projects the mutagen process on the host machine would rescan `src/vendor` and fail with the same `target references location outside synchronization root` error when it encounter the symlinks.

Mutagen documentation on symlinks shows two modes (portable, which is the default, an posix-raw) in which symlinks are synchronized. The default portable mode is restricted to symlinks which use relative paths and which do not point outside the synchronization root at any point in the target path. The posix-raw mode can be described as follows:

> posix-raw: In this mode, which is only supported for synchronization sessions between two POSIX endpoints, Mutagen will propagate raw symbolic link targets without any analysis or modification. Trying to use this mode when either endpoint is a Windows system will prevent synchronization from starting.

On one of these projects symlinks in vendor look like this:
```
$ ls -lh src/vendor/tpb/
total 0
lrwxr-xr-x  1 davidalger  admin    34B May 17 18:41 avalara-excise -> ../../libraries/tpb/avalara-excise
lrwxr-xr-x  1 davidalger  admin    40B May 17 18:41 grouppricefix -> ../../modules/tpb/module-group-price-fix
lrwxr-xr-x  1 davidalger  admin    36B May 17 18:41 module-content-management -> ../../modules/tpb/content-management
lrwxr-xr-x  1 davidalger  admin    37B May 17 18:41 module-seo-snippets -> ../../modules/tpb/module-seo-snippets
lrwxr-xr-x  1 davidalger  admin    42B May 17 18:41 module-urlrewritecleanup -> ../../modules/tpb/module-urlrewritecleanup
lrwxr-xr-x  1 davidalger  admin    25B May 17 18:41 solomon -> ../../modules/tpb/Solomon
```

Given this environment is specifically for running Magento atop Docker on macOS (which is POSIX) and uses Linux containers (also POSIX) switching to `posix-raw` mode should not pose a problem and completely solves the high CPU usage due to the constant re-scanning of the vendor directory on these projects.
