### PR TITLE
Added bin/dbconnect and bin/dbimport scripts

### DIFF
--- a/compose/magento-2/bin/dbconnect
+++ b/compose/magento-2/bin/dbconnect
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eu
+
+## change into directory one level above where this script is located allowing it to be run from anywhere
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )/.."
+
+source env/db.env
+docker-compose exec db \
+    mysql -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" "${MYSQL_DATABASE}" "$@"

--- a/compose/magento-2/bin/dbimport
+++ b/compose/magento-2/bin/dbimport
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eu
+
+## change into directory one level above where this script is located allowing it to be run from anywhere
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )/.."
+
+source env/db.env
+
+LC_ALL=C sed -e 's/DEFINER[ ]*=[ ]*[^*]*\*/\*/' | docker-compose exec -T db \
+    mysql -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" "${MYSQL_DATABASE}"


### PR DESCRIPTION
Use `bin/dbconnect` to drop into a mysql prompt for the `magento` database in the db container. Use `bin/dbimport` to re-import a database into a setup like this:

```
bin/dbconnect -e 'drop database magento; create database magento'
pv /server/dumps/vbm2/vbm2_main-2019-05-20.sql.gz | gunzip -c | bin/dbimport
```
