### PR TITLE
Implemented new mutagen session which will sync "/var/www/.composer/"…

### DIFF
--- a/compose/magento-2/bin/mutagen
+++ b/compose/magento-2/bin/mutagen
@@ -50,6 +50,21 @@ elif [[ "$1" == "start" ]]; then
         --symlink-mode=posix-raw \
         --ignore-vcs \
         docker://$(docker-compose ps -q phpfpm|awk '{print $1}')/var/www/html/vendor src/vendor
+
+    # sync files from docker /var/www/.composer/ to local ~/.composer/ after executing bin/composer commands,
+    # but keeping no-watch for both docker and local sides, so only "mutagen flush --all" will get the newest changes from the docker side (see bin/composer)
+    # please note that docker is alpha here.
+    mutagen create \
+        --default-file-mode-alpha=0644 \
+        --default-directory-mode-alpha=0755 \
+        --default-owner-alpha=app \
+        --default-group-alpha=app \
+        --sync-mode=two-way-resolved \
+        --watch-mode-alpha=no-watch \
+        --watch-mode-beta=no-watch \
+        --symlink-mode=posix-raw \
+        docker://$(docker-compose ps -q phpfpm|awk '{print $1}')/var/www/.composer/ ~/.composer/
+
 elif [[ "$1" == "stop" ]]; then
     mutagen terminate -a
     mutagen daemon stop

--- a/compose/magento-2/docker-compose.yml.sample
+++ b/compose/magento-2/docker-compose.yml.sample
@@ -32,7 +32,6 @@ services:
       - db
       - phpfpm
     volumes: &appvolumes
-      - ~/.composer:/var/www/.composer:delegated
       - appdata:/var/www/html
       - sockdata:/sock
 

--- a/compose/magento-2/parts/app/default.yml
+++ b/compose/magento-2/parts/app/default.yml
@@ -11,6 +11,5 @@ services:
       - db
       - phpfpm
     volumes: &appvolumes
-      - ~/.composer:/var/www/.composer:delegated
       - appdata:/var/www/html
       - sockdata:/sock

--- a/compose/magento-2/parts/app/varnish.yml
+++ b/compose/magento-2/parts/app/varnish.yml
@@ -12,7 +12,6 @@ services:
       - db
       - phpfpm
     volumes: &appvolumes
-      - ~/.composer:/var/www/.composer:delegated
       - appdata:/var/www/html
       - sockdata:/sock
 


### PR DESCRIPTION
Implemented new mutagen session which will sync "/var/www/.composer/" folder to local "~/.composer" folder when bin/composer command executed. Main purpose is to stop syncing the composer folder via Docker's :delegated config in docker-compose.yml