### PR TITLE
Fixed bin/bash to allow running from anywhere and to pass along any a…

### DIFF
--- a/compose/magento-2/bin/bash
+++ b/compose/magento-2/bin/bash
@@ -1,2 +1,7 @@
 #!/bin/bash
-bin/cli bash
+set -eu
+
+## change into directory one level above where this script is located allowing it to be run from anywhere
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )/.."
+
+bin/cli bash "$@"


### PR DESCRIPTION
* Allows bin/bash to be run from anywhere (was missed on my other PR)
* Passes any args received to bash inside the container (allows running, for example, something like `bin/bash -c 'ls -lh'` from the host)