### PR TITLE
Feature/self update improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The `-h` flag above (shorthand of `--help`) defines that setup script must only 
 - `bin/start`: Start all containers, good practice to use this instead of `docker-compose up -d`, as it may contain additional helpers.
 - `bin/status`: Check the container status.
 - `bin/stop`: Stop all containers.
-- `bin/update`: Update the contents of the bin folder with the latest changes from the master branch.
+- `bin/update`: Update the contents of the bin folder with the latest changes from the master branch and/or Docker images. Accepts optional arguments `-v|--version=<version>` (to specify version tag or branch path to fetch from, default is `master`), `-i|--images` updates only Docker images, `-a|--all` updates both bin scripts and Docker images. 
 - `bin/varnish`: Run commands in the Varnish container. Ex `bin/varnish varnishlog -q 'ReqURL ~ "^/$"'` to monitor requests to homepage, or `bin/vanirsh varnishlog -g request -q 'ReqMethod eq "PURGE"'` to monitor PURGE requests.
 - `bin/xdebug`: Disable or enable Xdebug. Accepts params `disable` (default) or `enable`. Ex. `bin/xdebug enable`.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The `-h` flag above (shorthand of `--help`) defines that setup script must only 
 - `bin/start`: Start all containers, good practice to use this instead of `docker-compose up -d`, as it may contain additional helpers.
 - `bin/status`: Check the container status.
 - `bin/stop`: Stop all containers.
-- `bin/update`: Update the contents of the bin folder with the latest changes from the master branch and/or Docker images along with the rebuilding of corresponding containers. Accepts optional arguments `-v|--version=<version>` (to specify version tag or branch path to fetch from, default is `master`, affects only bin scripts), `-i|--images` updates only Docker images, `-a|--all` updates both bin scripts and Docker images. 
+- `bin/update`: Update the contents of the bin folder with the latest changes from the master branch and/or Docker images along with the rebuilding of corresponding containers. Accepts optional arguments `-v|--version=<version>` (to specify version tag or branch path to fetch from, default is `master`, affects only bin scripts), `-i|--images` updates only Docker images along with the rebuilding of corresponding containers, `-a|--all` updates both bin scripts and Docker images along with the rebuilding of corresponding containers. 
 - `bin/varnish`: Run commands in the Varnish container. Ex `bin/varnish varnishlog -q 'ReqURL ~ "^/$"'` to monitor requests to homepage, or `bin/vanirsh varnishlog -g request -q 'ReqMethod eq "PURGE"'` to monitor PURGE requests.
 - `bin/xdebug`: Disable or enable Xdebug. Accepts params `disable` (default) or `enable`. Ex. `bin/xdebug enable`.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The `-h` flag above (shorthand of `--help`) defines that setup script must only 
 - `bin/start`: Start all containers, good practice to use this instead of `docker-compose up -d`, as it may contain additional helpers.
 - `bin/status`: Check the container status.
 - `bin/stop`: Stop all containers.
-- `bin/update`: Update the contents of the bin folder with the latest changes from the master branch and/or Docker images. Accepts optional arguments `-v|--version=<version>` (to specify version tag or branch path to fetch from, default is `master`), `-i|--images` updates only Docker images, `-a|--all` updates both bin scripts and Docker images. 
+- `bin/update`: Update the contents of the bin folder with the latest changes from the master branch and/or Docker images along with the rebuilding of corresponding containers. Accepts optional arguments `-v|--version=<version>` (to specify version tag or branch path to fetch from, default is `master`, affects only bin scripts), `-i|--images` updates only Docker images, `-a|--all` updates both bin scripts and Docker images. 
 - `bin/varnish`: Run commands in the Varnish container. Ex `bin/varnish varnishlog -q 'ReqURL ~ "^/$"'` to monitor requests to homepage, or `bin/vanirsh varnishlog -g request -q 'ReqMethod eq "PURGE"'` to monitor PURGE requests.
 - `bin/xdebug`: Disable or enable Xdebug. Accepts params `disable` (default) or `enable`. Ex. `bin/xdebug enable`.
 

--- a/compose/magento-2/bin/update
+++ b/compose/magento-2/bin/update
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -e
 
 ## change into directory one level above where this script is located allowing it to be run from anywhere
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )/.."
@@ -7,27 +7,35 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )/.."
 for i in "$@"
     do
         case ${i} in
-            -v=*) VERSION="${i#*=}"; shift;;
-            --version=*) VERSION="${i#*=}"; shift;;
+            -v=*|--version=*) VERSION="${i#*=}"; shift;;
+            -i|--images) IMAGES=1; shift;;
+            -a|--all) ALL=1; shift;;
             *) ;;
         esac
     done
 
-VERSION=${VERSION:-master}
+if [[ ! -z "$ALL" ]] || [[ -z "$IMAGES" ]]; then
+    printf "Fetching latest version..."
+    VERSION=${VERSION:-master}
+    rm -rf tmp-mage2click
+    mkdir tmp-mage2click
+    cd tmp-mage2click
+    git init -qqq
+    git remote add origin https://github.com/mage2click/docker-magento-mutagen
+    git fetch origin -qqq
+    git checkout origin/${VERSION} -- compose/magento-2
+    rm -rf ../bin
+    cp -Rf compose/magento-2/bin ../
+    cd ../
+    rm -rf tmp-mage2click
+    printf " DONE!"
+fi
 
-echo
-printf "Fetching latest version..."
-rm -rf tmp-mage2click
-mkdir tmp-mage2click
-cd tmp-mage2click
-git init -qqq
-git remote add origin https://github.com/mage2click/docker-magento-mutagen
-git fetch origin -qqq
-git checkout origin/${VERSION} -- compose/magento-2
-rm -rf ../bin
-cp -Rf compose/magento-2/bin ../
-cd ../
-rm -rf tmp-mage2click
-printf " DONE!"
-echo
-echo
+if [[ ! -z "$ALL" ]] || [[ ! -z "$IMAGES" ]]; then
+    bin/mutagen stop || true
+    docker-compose down --rmi all
+    docker-compose up -d
+    bin/fixowns # Fix for Mutagen Error: create failed: unable to connect to beta: unable to connect to endpoint:
+                # unable to install agent: unable to invoke agent installation: exit status 1
+    bin/mutagen start
+fi

--- a/compose/magento-2/bin/update
+++ b/compose/magento-2/bin/update
@@ -10,9 +10,17 @@ for i in "$@"
             -v=*|--version=*) VERSION="${i#*=}"; shift;;
             -i|--images) IMAGES=1; shift;;
             -a|--all) ALL=1; shift;;
-            *) ;;
+            *)
+                >&2 ERROR="$ERROR $i"
+                ;;
         esac
     done
+
+if [[ ! -z "$ERROR" ]]; then
+    echo
+    printf "\e[01;31mError: Unrecognized argument: %s\n\e[m" ${ERROR}
+    exit
+fi
 
 if [[ ! -z "$ALL" ]] || [[ -z "$IMAGES" ]]; then
     printf "Fetching latest version..."


### PR DESCRIPTION
Update the contents of the bin folder with the latest changes from the master branch and/or Docker images along with the rebuilding of corresponding containers.

Accepts optional arguments:

- `-v|--version=<version>` to specify version tag or branch path to fetch from, default is master 
- `-i|--images` updates only Docker images along with the rebuilding of corresponding containers
- `-a|--all` updates both bin scripts and Docker images along with the rebuilding of corresponding containers