### PR TITLE
Moved creating of the nginx.conf file 

### DIFF
--- a/compose/magento-2/bin/setup/start
+++ b/compose/magento-2/bin/setup/start
@@ -49,8 +49,6 @@ docker-compose up -d
 
 sleep 1 #Ensure containers are started...
 
-cp ${CONTAINER_SRC_SYNC_DIR}/nginx.conf.sample ${CONTAINER_SRC_SYNC_DIR}/nginx.conf #create nginx.conf from sample
-
 echo "Copying all files from host to the container..."
 bin/copytocontainer --all
 bin/fixperms
@@ -119,6 +117,8 @@ if [[ ! -z "$COMPOSER" ]]; then
     echo "Forcing reinstall of composer deps to ensure perms & reqs..."
     bin/clinotty composer install
 fi
+
+cp ${CONTAINER_SRC_SYNC_DIR}/nginx.conf.sample ${CONTAINER_SRC_SYNC_DIR}/nginx.conf #create nginx.conf from sample
 
 if [[ -z "$DB" ]]; then
     bin/clinotty bin/magento setup:install \


### PR DESCRIPTION
Moved creating of the nginx.conf file  to the place where we will have… all files generated after composer install, so it will not throw error about missing "nginx.conf.sample" file during the vanilla magento cloud project setup