### PR TITLE
Fix issue when using bin/mr

### DIFF
--- a/compose/magento-2/bin/mr
+++ b/compose/magento-2/bin/mr
@@ -3,4 +3,4 @@ set -eu
 ## change into directory one level above where this script is located allowing it to be run from anywhere
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )/.."
 
-bin/cli n98-magerun2.phar "$@"
+bin/cli php n98-magerun2.phar "$@"


### PR DESCRIPTION
Without this fix I have this issue when running bin/mr sys:info (or something else) 
"OCI runtime exec failed: exec failed: container_linux.go:346: starting container process caused "exec: \"n98-magerun2.phar\": executable file not found in $PATH": unknown"

I'm a Mac OS user.